### PR TITLE
Remove unsafe implementations of Send & Sync

### DIFF
--- a/wooting-analog-midi-core/src/lib.rs
+++ b/wooting-analog-midi-core/src/lib.rs
@@ -330,11 +330,6 @@ pub struct MidiService {
     pub note_config: NoteConfig,
 }
 
-//TODO: Determine if this is safe (LUL imagine saying it may be safe when it literally says unsafe) or a different solution is required
-// Tbf haven't ran into any issues yet, so might be okay
-unsafe impl Send for MidiService {}
-unsafe impl Sync for MidiService {}
-
 impl MidiService {
     pub fn new() -> Self {
         MidiService {


### PR DESCRIPTION
As far as I can see those implementations aren't needed (anymore), as I've built the project successfully without either implementation. And MidiService should be at least Send through derivation either way.